### PR TITLE
SshHelper does not catch IllegalArgumentException

### DIFF
--- a/src/main/java/com/urbancode/terraform/tasks/aws/helpers/SshHelper.java
+++ b/src/main/java/com/urbancode/terraform/tasks/aws/helpers/SshHelper.java
@@ -146,6 +146,9 @@ public class SshHelper {
     //----------------------------------------------------------------------------------------------
     static public boolean isPortActive(String host, int port) {
         Socket s = null;
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Port value passed is outside the specified range of valid port values");
+        }
         try {
             s = new Socket();
             s.setReuseAddress(true);

--- a/src/test/java/org/urbancode/terraform/tasks/helpers/SshHelperTest.java
+++ b/src/test/java/org/urbancode/terraform/tasks/helpers/SshHelperTest.java
@@ -1,0 +1,17 @@
+package org.urbancode.terraform.tasks.helpers;
+
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.urbancode.terraform.tasks.aws.helpers.SshHelper;
+
+public class SshHelperTest {
+
+    @Test(expected=IllegalArgumentException.class)
+    public void isPortActiveTest() {
+        SshHelper.isPortActive("127.0.0.1", 65536);
+    }
+
+}


### PR DESCRIPTION
SshHelper.java calls `java.net.InetSocketAddress` without first
checking that port number is within range of valid port values (0 to 65535, inclusive).
This cause an uncaught `IllegalArgumentException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/net/InetSocketAddress.html#InetSocketAddress%28int%29). 

This pull request adds a check and a test for this issue.
